### PR TITLE
Fix nested list items are ignored

### DIFF
--- a/src/check-outstanding-tasks.js
+++ b/src/check-outstanding-tasks.js
@@ -11,6 +11,10 @@ module.exports = function (body) {
     let tokens = marked.lexer(body, { gfm: true });
     // flatten the nested tokens to make filtering easier
     let allTokens = tokens.flatMap(function mapper(token) {
+        if (token.tokens && token.tokens.length > 1) {
+            return token.tokens.flatMap(mapper);
+        }
+
         return token.items && token.items.length ? token.items.flatMap(mapper) : [token];
     });
     // and filter down to just the task list items

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -44,3 +44,19 @@ Hello World
     expect(results.total).toBe(2);
     expect(results.remaining).toBe(1);
 });
+
+test('Test nested lists', () => {
+    let markdown = `
+Hello World
+- [x] normal
+- section1
+   - [x] task 1-1
+   - [ ] task 1-2
+- section2
+   - [ ] task 2-1
+   - [x] task 2-2
+`;
+    let results = checkOutstandingTasks(markdown);
+    expect(results.total).toBe(5);
+    expect(results.remaining).toBe(2);
+});


### PR DESCRIPTION
Currently, if a target description is the following,

```md
- [x] normal
- section1
   - [x] task 1-1
   - [ ] task 1-2
- section2
   - [ ] task 2-1
   - [x] task 2-2
```

then, the result is `total 3, and remaining 0`. My change makes it `total 5, and remaining 2`.

This behavior seems to have changed since fea1d5f11599d88402cb94aa6649a9d9dc3f9c04.