### PR TITLE
Add merge queue support for task-list-completed checks

### DIFF
--- a/app.yml
+++ b/app.yml
@@ -23,6 +23,7 @@ default_events:
 # - fork
 # - gollum
  - issue_comment
+ - merge_group
 # - issues
 # - label
 # - milestone

--- a/index.js
+++ b/index.js
@@ -5,6 +5,36 @@ const ENABLE_ID_LOGS = true; // Repo name & ID only for logs, no private data lo
 module.exports = (app) => {
   app.log('Yay! The app was loaded!');
 
+  // handle merge queue events - a PR can only enter the merge queue after all
+  // required checks (including task-list-completed) have already passed, so we
+  // can immediately report success here to unblock the queue.
+  app.on('merge_group.checks_requested', async context => {
+    const headSha = context.payload.merge_group.head_sha;
+    const prRepo = context.payload.repository.full_name;
+
+    context.log.info(`PR ${prRepo}: Merge queue check requested for ${headSha}, reporting success`);
+
+    const check = {
+      name: 'task-list-completed',
+      head_sha: headSha,
+      status: 'completed',
+      conclusion: 'success',
+      started_at: (new Date).toISOString(),
+      completed_at: (new Date).toISOString(),
+      output: {
+        title: 'All tasks already verified',
+        summary: 'Tasks were already checked before this PR entered the merge queue',
+      },
+    };
+
+    try {
+      const response = await context.octokit.checks.create(context.repo(check));
+      context.log.info(`PR ${prRepo}: Merge queue check response status ${response.status}`);
+    } catch (err) {
+      context.log.error(`PR ${prRepo}: Error sending merge queue check. Error (${err.status}): ${err.message}`);
+    }
+  });
+
   // watch for pull requests & their changes
   app.on([
     'pull_request.opened',


### PR DESCRIPTION
## Summary

Fixes #34

This change adds support for GitHub's merge queue feature by automatically reporting success for the `task-list-completed` check when a PR enters the merge queue. Since all required checks (including task-list-completed) must pass before a PR can enter the queue, we can immediately report success to unblock the merge queue process.

## Key Changes
- Added handler for `merge_group.checks_requested` webhook events that automatically creates a successful check result
- Registered the `merge_group` event in the app configuration to enable webhook delivery
- The check is reported with appropriate metadata (timestamps, output summary) to indicate that task verification was already completed before queue entry

## Implementation Details
- The handler extracts the merge group head SHA and repository information from the webhook payload
- Creates a check with `status: 'completed'` and `conclusion: 'success'` to unblock the merge queue
- Includes error handling and logging for debugging merge queue check failures
- The implementation leverages the fact that task-list-completed checks are prerequisites for queue entry, eliminating the need for re-verification

https://claude.ai/code/session_01HepeugYCc2ET3qmnfz3veg