### PR TITLE
fix(comments): ignore comments and checkboxes from coderabbit bot

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,13 +88,13 @@ module.exports = (app) => {
     }
 
     log(`Request received [Context: ${context.id}]`);
-    
+
     // if the author is a renovate bot, ignore checks
     // https://www.mend.io/free-developer-tools/renovate/
     if (prUser.indexOf('renovate[bot]') !== -1) {
       prBody = null;
     }
-    
+
     let outstandingTasks = checkOutstandingTasks(prBody);
 
 
@@ -110,6 +110,7 @@ module.exports = (app) => {
       let bots = [
         'linear', // ref https://github.com/stilliard/github-task-list-completed/issues/33
         'linear[bot]',
+        'coderabbitai[bot]',
       ];
       // filter out comments from the bot
       comments.data = comments.data.filter(comment => {


### PR DESCRIPTION
CodeRabbit's "Finishing Touches" feature uses checkboxes in its walkthrough comment as interactive triggers for actions such as generating unit tests or applying fixes. See the [CodeRabbit Finishing Touches docs](https://docs.coderabbit.ai/finishing-touches) for details.

This causes the check to block merging on PRs where CodeRabbit has posted review comments, even when all genuine author-defined tasks are complete.

This change adds `coderabbitai[bot]` to the list of bot users whose comments are excluded from the task list check, consistent with the existing handling for `linear[bot]`.