### PR TITLE
fix(comments): ignore checkboxes from bots on all comment types

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,15 @@ By default, we mark the check as in_progress until all tasks pass and then it ma
 ## Skippable tasks
 
 Tasks that contain "POST-MERGE" or "N/A" in all caps are skipped. This is useful for tasks that are not applicable to the PR, or tasks that are only applicable after the PR is merged.
-This was inspired by [another project here](https://github.com/Shopify/task-list-checker/tree/main?tab=readme-ov-file#in-a-pull-request). 
+This was inspired by [another project here](https://github.com/Shopify/task-list-checker/tree/main?tab=readme-ov-file#in-a-pull-request).
 
 ## Optional tasks
 
 Tasks that contain "OPTIONAL" in all caps are also skipped unless checked, they are also added to an "(+X optional)" text in the check. This is useful for tasks that are not required to be completed before the PR can be merged.
+
+## Bots
+
+Checkboxes added by PR bots are automatically excluded from the task list guard. Bots currently excluded: `linear`, `coderabbitai`
 
 ## Contributing / Development
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const checkOutstandingTasks = require('./src/check-outstanding-tasks');
+const isBotComment = require('./src/is-bot-comment');
 
 const ENABLE_ID_LOGS = true; // Repo name & ID only for logs, no private data logged! (Repo name only needed to help with issue reports & debugging).
 
@@ -105,20 +106,6 @@ module.exports = (app) => {
         per_page: 100,
         issue_number: prNumber
       }));
-
-      // bots to ignore
-      let bots = [
-        'linear', // ref https://github.com/stilliard/github-task-list-completed/issues/33
-        'linear[bot]',
-        'coderabbitai[bot]',
-      ];
-      // filter out comments from the bot
-      comments.data = comments.data.filter(comment => {
-        return ! bots.includes(comment.user.login);
-      });
-      // cleanup
-      bots = null;
-
     } catch (err) {
       if (err.status === 403) { // if we don't have access to the repo, skip entirely
         log(`No access, skipping entirely. Error (${err.status}): ${err.message}`, 'error');
@@ -167,6 +154,8 @@ module.exports = (app) => {
     // & check them for tasks
     if (comments && comments.data && comments.data.length) {
       comments.data.forEach(function (comment) {
+        if (isBotComment(comment)) return
+
         let commentOutstandingTasks = checkOutstandingTasks(comment.body);
         outstandingTasks.total += commentOutstandingTasks.total;
         outstandingTasks.remaining += commentOutstandingTasks.remaining;

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "jest": "^29.7.0",
+    "nock": "^14.0.15",
     "smee-client": "1.2"
   }
 }

--- a/src/is-bot-comment.js
+++ b/src/is-bot-comment.js
@@ -1,0 +1,9 @@
+const BOTS_TO_IGNORE = new Set([
+  'linear', // ref https://github.com/stilliard/github-task-list-completed/issues/33
+  'linear[bot]',
+  'coderabbitai[bot]',
+]);
+
+module.exports = (comment) => {
+  return BOTS_TO_IGNORE.has(comment?.user?.login ?? "");
+}

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -122,7 +122,7 @@ describe('ignores bot checkbox comments across all comment types', () => {
         'linear[bot]',
         'coderabbitai[bot]',
     ])('ignores checkbox comments from %s', async (botLogin) => {
-        const botComment = { user: { login: botLogin }, body: '- [ ] bot task' };
+        const botComment = { user: { login: botLogin }, body: '- [ ] bot task' }; // Should not be a blocking task
         let capturedTitle;
 
         nock('https://api.github.com')
@@ -141,7 +141,7 @@ describe('ignores bot checkbox comments across all comment types', () => {
                 action: 'opened',
                 pull_request: {
                     number: prNumber,
-                    body: '- [ ] human task',
+                    body: '- [ ] human task', // Should show up as 1 blocking task
                     user: { login: 'devuser' },
                     head: { repo: { full_name: `${owner}/${repo}` } },
                 },

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -2,6 +2,10 @@
 // To read more about testing with Probot, visit https://probot.github.io/docs/testing/
 
 const checkOutstandingTasks = require('../src/check-outstanding-tasks');
+const nock = require('nock');
+const { Probot, ProbotOctokit } = require('probot');
+const app = require('../index.js')
+
 test('Test outstanding tasks found', () => {
     let markdown = `
 Hello World
@@ -88,4 +92,63 @@ Hello World
     expect(results.total).toBe(2);
     expect(results.remaining).toBe(0);
     expect(results.optionalRemaining).toBe(1);
+});
+
+describe('ignores bot checkbox comments across all comment types', () => {
+    let probot;
+    beforeEach(() => {
+        nock.disableNetConnect();
+        probot = new Probot({
+            githubToken: 'test',
+            Octokit: ProbotOctokit.defaults({
+                retry: { enabled: false },
+                throttle: { enabled: false },
+            }),
+        });
+        probot.load(app);
+    });
+
+    afterEach(() => {
+        nock.cleanAll();
+        nock.enableNetConnect();
+    });
+
+    const owner = 'octo';
+    const repo = 'repo';
+    const prNumber = 1;
+
+    test.each([
+        'linear',
+        'linear[bot]',
+        'coderabbitai[bot]',
+    ])('ignores checkbox comments from %s', async (botLogin) => {
+        const botComment = { user: { login: botLogin }, body: '- [ ] bot task' };
+        let capturedTitle;
+
+        nock('https://api.github.com')
+            .get(`/repos/${owner}/${repo}/issues/${prNumber}/comments`).query(true).reply(200, [botComment])
+            .get(`/repos/${owner}/${repo}/pulls/${prNumber}/reviews`).query(true).reply(200, [botComment])
+            .get(`/repos/${owner}/${repo}/pulls/${prNumber}/comments`).query(true).reply(200, [botComment])
+            .post(`/repos/${owner}/${repo}/check-runs`, (body) => {
+                capturedTitle = body.output.title;
+                return true;
+            })
+            .reply(201, {});
+
+        await probot.receive({
+            name: 'pull_request',
+            payload: {
+                action: 'opened',
+                pull_request: {
+                    number: prNumber,
+                    body: '- [ ] human task',
+                    user: { login: 'devuser' },
+                    head: { repo: { full_name: `${owner}/${repo}` } },
+                },
+                repository: { owner: { login: owner }, name: repo },
+            },
+        });
+
+        expect(capturedTitle).toBe('0 / 1 tasks completed');
+    });
 });


### PR DESCRIPTION
The previous bot filter was only being applied to comments returned from `listComments`. However, tasks can potentially appear across other comment types: `listReviews`, `listReviewComments`. Coderabbit can sometimes add blocking tasks to these other comment types as well.

This change just moves the bot filter to ignore *all* comment types.

I also added a Probot test that exercises the logic for the entire pull request handler which required adding `nock` as a dev dependency. 