### PR TITLE
Add cluster support to multiply outbound write throughput

### DIFF
--- a/cluster.js
+++ b/cluster.js
@@ -1,0 +1,22 @@
+const cluster = require('cluster');
+
+if (cluster.isPrimary) {
+  const workers = parseInt(process.env.WEB_CONCURRENCY, 10) || 4;
+  console.log(`Primary ${process.pid} starting ${workers} workers`);
+  for (let i = 0; i < workers; i++) cluster.fork();
+
+  // resurrect a worker if it dies, unless we're shutting down
+  let shuttingDown = false;
+  cluster.on('exit', (worker, code, signal) => {
+    console.log(`Worker ${worker.process.pid} died (${signal || code})`);
+    if (!shuttingDown) cluster.fork();
+  });
+  for (const sig of ['SIGTERM', 'SIGINT']) {
+    process.on(sig, () => {
+      shuttingDown = true;
+      for (const w of Object.values(cluster.workers)) w.kill(sig);
+    });
+  }
+} else {
+  require('probot').run(require('./index'));
+}

--- a/cluster.js
+++ b/cluster.js
@@ -3,14 +3,28 @@ const cluster = require('cluster');
 if (cluster.isPrimary) {
   const workers = parseInt(process.env.WEB_CONCURRENCY, 10) || 4;
   console.log(`Primary ${process.pid} starting ${workers} workers`);
-  for (let i = 0; i < workers; i++) cluster.fork();
+  for (let i = 0; i < workers; i++) fork();
 
-  // resurrect a worker if it dies, unless we're shutting down
+  // resurrect a worker if it dies, unless we're shutting down, also track fast crashes and exit if too many happen in a row
   let shuttingDown = false;
+  let fastCrashes = 0;
   cluster.on('exit', (worker, code, signal) => {
-    console.log(`Worker ${worker.process.pid} died (${signal || code})`);
-    if (!shuttingDown) cluster.fork();
+    if (shuttingDown) return;
+    const ranForMs = Date.now() - worker.startedAt;
+    if (ranForMs < 5000) {
+      fastCrashes++;
+      console.error(`Worker ${worker.process.pid} died after ${ranForMs}ms (${signal || code}) [fast-crash ${fastCrashes}/${workers}]`);
+      if (fastCrashes >= workers) {
+        console.error('Too many fast worker crashes; exiting for the service manager to restart.');
+        process.exit(1);
+      }
+    } else {
+      fastCrashes = 0; // a healthy run clears the streak
+      console.log(`Worker ${worker.process.pid} died after ${Math.round(ranForMs / 1000)}s (${signal || code}); respawning`);
+    }
+    fork();
   });
+
   for (const sig of ['SIGTERM', 'SIGINT']) {
     process.on(sig, () => {
       shuttingDown = true;
@@ -18,5 +32,11 @@ if (cluster.isPrimary) {
     });
   }
 } else {
-  require('probot').run(require('./index'));
+  require('probot').run([process.argv[0], process.argv[1], './index.js']);
+}
+
+function fork() {
+  const worker = cluster.fork();
+  worker.startedAt = Date.now();
+  return worker;
 }

--- a/cluster.js
+++ b/cluster.js
@@ -1,7 +1,8 @@
 const cluster = require('cluster');
 
 if (cluster.isPrimary) {
-  const workers = parseInt(process.env.WEB_CONCURRENCY, 10) || 4;
+  const requested = parseInt(process.env.WEB_CONCURRENCY, 10);
+  const workers = Number.isInteger(requested) && requested > 0 ? requested : 4;
   console.log(`Primary ${process.pid} starting ${workers} workers`);
   for (let i = 0; i < workers; i++) fork();
 
@@ -32,6 +33,7 @@ if (cluster.isPrimary) {
     });
   }
 } else {
+  // equivalent to `probot run ./index.js` (app path passed as a positional arg)
   require('probot').run([process.argv[0], process.argv[1], './index.js']);
 }
 

--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
   "license": "ISC",
   "repository": "https://github.com/stilliard/github-task-list-completed.git",
   "scripts": {
-    "dev-debug": "nodemon --exec \"LOG_LEVEL=debug npm start\"",
-    "dev": "nodemon --exec \"npm start\"",
-    "start": "probot run ./index.js",
+    "dev-debug": "nodemon --exec \"LOG_LEVEL=debug npm run start:single\"",
+    "dev": "nodemon --exec \"npm run start:single\"",
+    "start": "node cluster.js",
+    "start:single": "probot run ./index.js",
     "test": "jest"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

Under load, the final `checks.create` call lags by minutes while the preceding GET lookups stay fast. Octokit's throttling plugin serializes **writes** at `maxConcurrent: 1, minTime: 1000` (~1 write/sec), keyed per installation and queued **in-memory per process**. A busy installation backs up behind that gate. (Confirmed via logs + an LB experiment: pausing one node drained the backlog; no GitHub secondary-rate 403s involved.)

## Key Changes

Add a small `cluster.js` entrypoint. The primary forks `WEB_CONCURRENCY` workers (default 4), each running the existing Probot app unchanged. Each worker gets its **own** in-memory write queue, so aggregate write throughput scales with worker count. The queue is timer-gated (idle-waiting), so this helps **even on single-core droplets** — it's process count, not core count, that matters here.

- `start` → `node cluster.js`; `start:single` keeps the prior single-process path.
- `dev` / `dev-debug` pinned to `start:single` so local smee dev doesn't fan out events across workers.
- Crashed workers respawn; a burst of fast (startup) crashes makes the primary exit so the service manager can restart with backoff.
- SIGTERM/SIGINT shuts workers down cleanly without respawn.
- Worker mirrors `probot run ./index.js` exactly, so the default app's `/` and `/probot` routes are preserved.

Redis is intentionally left off — wiring `redisConfig` would share one queue fleet-wide and re-impose 1 write/sec globally per installation (worse for throughput).

## Testing

1. Ensure `WEBHOOK_PROXY_URL` is **unset** in production (smee would cause fan-out there too).
2. Set `WEB_CONCURRENCY` if you want something other than 4 (start conservative).
3. Confirm the systemd unit has `Restart=on-failure` + `RestartSec` so the fast-crash exit self-heals with backoff.

After deploy on one droplet:
- `ps -ef | grep cluster.js` → 1 primary + N workers.
- No duplicate processing: `journalctl -u <svc> | grep "Request received" | grep -oE "Context: [a-f0-9-]+" | sort | uniq -c` → all counts `1`.
- Watch the "Complete and sending back" → "Check response status 201" gap shrink vs. the unchanged droplet; watch for any `secondary rate limit` 403s (expected: none).

🤖 Generated with [Claude Code](https://claude.com/claude-code)